### PR TITLE
indexer: pass network related parameters through config

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1303,6 +1303,10 @@ func setIndexerConfig(ctx *cli.Context, cfg *dex.Config) {
 
 	cfg.Indexer.Plugin = ctx.GlobalString(IndexerPluginFlag.Name)
 	cfg.Indexer.PluginFlags = ctx.GlobalString(IndexerPluginFlagsFlag.Name)
+	// copy required dex configs
+	cfg.Indexer.Genesis = cfg.Genesis
+	cfg.Indexer.NetworkID = cfg.NetworkId
+	cfg.Indexer.SyncMode = cfg.SyncMode
 }
 
 // SetDashboardConfig applies dashboard related command line flags to the config.

--- a/indexer/config.go
+++ b/indexer/config.go
@@ -2,6 +2,9 @@ package indexer
 
 import (
 	"plugin"
+
+	"github.com/dexon-foundation/dexon/core"
+	"github.com/dexon-foundation/dexon/dex/downloader"
 )
 
 // Config is data sources related configs struct.
@@ -14,6 +17,13 @@ type Config struct {
 
 	// PluginFlags for construction if needed.
 	PluginFlags string
+
+	// The genesis block from dex.Config
+	Genesis *core.Genesis
+
+	// Protocol options from dex.Config (partial)
+	NetworkID uint64
+	SyncMode  downloader.SyncMode
 }
 
 // NewIndexerFromConfig initialize exporter according to given config.


### PR DESCRIPTION
Pass following network related params:

* Genesis block
* Network ID

And sync mode for indexer configuration.