### PR TITLE
core: vm: sqlvm: add more built-in functions

### DIFF
--- a/core/vm/sqlvm/runtime/functions.go
+++ b/core/vm/sqlvm/runtime/functions.go
@@ -28,6 +28,7 @@ const (
 	RAND
 	BITAND
 	BITOR
+	BITXOR
 )
 
 type fn func(*common.Context, []*Operand, uint64) (*Operand, error)
@@ -46,6 +47,7 @@ var (
 		RAND:           fnRand,
 		BITAND:         fnBitAnd,
 		BITOR:          fnBitOr,
+		BITXOR:         fnBitXor,
 	}
 )
 
@@ -332,6 +334,24 @@ func fnBitOr(ctx *common.Context, ops []*Operand, length uint64) (result *Operan
 			op2.Data[i],
 			op1.Meta,
 			func(b1, b2 byte) byte { return b1 | b2 },
+		)
+	}
+	return
+}
+
+func fnBitXor(ctx *common.Context, ops []*Operand, length uint64) (result *Operand, err error) {
+	n, op1, op2, err := extractOps(ops)
+	if err != nil {
+		return
+	}
+
+	result = op1.clone(true)
+	result.Data = make([]Tuple, n)
+	for i := 0; i < n; i++ {
+		result.Data[i] = op1.Data[i].bitBinOp(
+			op2.Data[i],
+			op1.Meta,
+			func(b1, b2 byte) byte { return b1 ^ b2 },
 		)
 	}
 	return

--- a/core/vm/sqlvm/runtime/functions.go
+++ b/core/vm/sqlvm/runtime/functions.go
@@ -27,6 +27,7 @@ const (
 	NOW
 	RAND
 	BITAND
+	BITOR
 )
 
 type fn func(*common.Context, []*Operand, uint64) (*Operand, error)
@@ -44,6 +45,7 @@ var (
 		TXORIGIN:       fnTxOrigin,
 		RAND:           fnRand,
 		BITAND:         fnBitAnd,
+		BITOR:          fnBitOr,
 	}
 )
 
@@ -314,5 +316,23 @@ func (r *Raw) bitBinOp(r2 *Raw, dType ast.DataType, bFn bitBinFunc) (r3 *Raw) {
 
 	r3 = &Raw{}
 	r3.fromBytes(bytes3, dType)
+	return
+}
+
+func fnBitOr(ctx *common.Context, ops []*Operand, length uint64) (result *Operand, err error) {
+	n, op1, op2, err := extractOps(ops)
+	if err != nil {
+		return
+	}
+
+	result = op1.clone(true)
+	result.Data = make([]Tuple, n)
+	for i := 0; i < n; i++ {
+		result.Data[i] = op1.Data[i].bitBinOp(
+			op2.Data[i],
+			op1.Meta,
+			func(b1, b2 byte) byte { return b1 | b2 },
+		)
+	}
 	return
 }

--- a/core/vm/sqlvm/runtime/instructions_op_test.go
+++ b/core/vm/sqlvm/runtime/instructions_op_test.go
@@ -3985,3 +3985,74 @@ func (s *instructionSuite) TestOpFuncOctetLength() {
 
 	s.run(testcases, opFunc)
 }
+
+func (s *instructionSuite) TestOpFuncSubString() {
+	testcases := []opTestcase{
+		{
+			"Func sub string",
+			Instruction{
+				Op: FUNC,
+				Input: []*Operand{
+					makeOperand(
+						true,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 0),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(2)}},
+						},
+					),
+					makeOperand(
+						true,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 1),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(15)}},
+						},
+					),
+					makeOperand(
+						false,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorDynamicBytes, 0),
+						},
+						[]Tuple{
+							{&Raw{Bytes: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}}},
+						},
+					),
+					makeOperand(
+						true,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 7),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(2)}},
+						},
+					),
+					makeOperand(
+						true,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 7),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(5)}},
+						},
+					),
+				},
+				Output: 0,
+			},
+			makeOperand(
+				false,
+				[]ast.DataType{
+					ast.ComposeDataType(ast.DataTypeMajorDynamicBytes, 0),
+				},
+				[]Tuple{
+					{&Raw{Bytes: []byte{3, 4, 5, 6, 7}}},
+				},
+			),
+			nil,
+		},
+	}
+
+	s.run(testcases, opFunc)
+}

--- a/core/vm/sqlvm/runtime/instructions_op_test.go
+++ b/core/vm/sqlvm/runtime/instructions_op_test.go
@@ -3932,3 +3932,56 @@ func (s *instructionSuite) TestOpFuncBitNot() {
 
 	s.run(testcases, opFunc)
 }
+
+func (s *instructionSuite) TestOpFuncOctetLength() {
+	testcases := []opTestcase{
+		{
+			"Func octet length",
+			Instruction{
+				Op: FUNC,
+				Input: []*Operand{
+					makeOperand(
+						true,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 0),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(2)}},
+						},
+					),
+					makeOperand(
+						true,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 1),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(14)}},
+						},
+					),
+					makeOperand(
+						false,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorDynamicBytes, 0), ast.ComposeDataType(ast.DataTypeMajorDynamicBytes, 0), ast.ComposeDataType(ast.DataTypeMajorDynamicBytes, 0), ast.ComposeDataType(ast.DataTypeMajorDynamicBytes, 0), ast.ComposeDataType(ast.DataTypeMajorDynamicBytes, 0),
+						},
+						[]Tuple{
+							{&Raw{Bytes: []byte{}}, &Raw{Bytes: []byte{1}}, &Raw{Bytes: []byte{1, 2}}, &Raw{Bytes: []byte{1, 2, 3}}, &Raw{Bytes: []byte{1, 2, 3, 4}}},
+						},
+					),
+				},
+				Output: 0,
+			},
+			makeOperand(
+				false,
+				[]ast.DataType{
+					ast.ComposeDataType(ast.DataTypeMajorUint, 32), ast.ComposeDataType(ast.DataTypeMajorUint, 32), ast.ComposeDataType(ast.DataTypeMajorUint, 32), ast.ComposeDataType(ast.DataTypeMajorUint, 32), ast.ComposeDataType(ast.DataTypeMajorUint, 32),
+				},
+				[]Tuple{
+					{&Raw{Value: decimal.NewFromFloat(0)}, &Raw{Value: decimal.NewFromFloat(1)}, &Raw{Value: decimal.NewFromFloat(2)}, &Raw{Value: decimal.NewFromFloat(3)}, &Raw{Value: decimal.NewFromFloat(4)}},
+				},
+			),
+			nil,
+		},
+	}
+
+	s.run(testcases, opFunc)
+}

--- a/core/vm/sqlvm/runtime/instructions_op_test.go
+++ b/core/vm/sqlvm/runtime/instructions_op_test.go
@@ -3879,3 +3879,56 @@ func (s *instructionSuite) TestOpFuncBitXor() {
 
 	s.run(testcases, opFunc)
 }
+
+func (s *instructionSuite) TestOpFuncBitNot() {
+	testcases := []opTestcase{
+		{
+			"Func BitNot",
+			Instruction{
+				Op: FUNC,
+				Input: []*Operand{
+					makeOperand(
+						true,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 0),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(2)}},
+						},
+					),
+					makeOperand(
+						true,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 1),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(13)}},
+						},
+					),
+					makeOperand(
+						false,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(128)}, &Raw{Value: decimal.NewFromFloat(0)}, &Raw{Value: decimal.NewFromFloat(-1)}, &Raw{Value: decimal.NewFromFloat(-128)}, &Raw{Bytes: []byte{0x12, 0x34}}, &Raw{Bytes: []byte{0xff, 0x00}}},
+						},
+					),
+				},
+				Output: 0,
+			},
+			makeOperand(
+				false,
+				[]ast.DataType{
+					ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0),
+				},
+				[]Tuple{
+					{&Raw{Value: decimal.NewFromFloat(127)}, &Raw{Value: decimal.NewFromFloat(255)}, &Raw{Value: decimal.NewFromFloat(0)}, &Raw{Value: decimal.NewFromFloat(127)}, &Raw{Bytes: []byte{0xed, 0xcb}}, &Raw{Bytes: []byte{0x00, 0xff}}},
+				},
+			),
+			nil,
+		},
+	}
+
+	s.run(testcases, opFunc)
+}

--- a/core/vm/sqlvm/runtime/instructions_op_test.go
+++ b/core/vm/sqlvm/runtime/instructions_op_test.go
@@ -3755,3 +3755,65 @@ func (s *instructionSuite) TestOpFuncBitAnd() {
 
 	s.run(testcases, opFunc)
 }
+
+func (s *instructionSuite) TestOpFuncBitOr() {
+	testcases := []opTestcase{
+		{
+			"Func BitOr",
+			Instruction{
+				Op: FUNC,
+				Input: []*Operand{
+					makeOperand(
+						true,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 0),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(2)}},
+						},
+					),
+					makeOperand(
+						true,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 1),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(11)}},
+						},
+					),
+					makeOperand(
+						false,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(1)}, &Raw{Value: decimal.NewFromFloat(2)}, &Raw{Value: decimal.NewFromFloat(-1)}, &Raw{Value: decimal.NewFromFloat(-128)}, &Raw{Bytes: []byte{0x12, 0x34}}, &Raw{Bytes: []byte{0x56, 0x78}}},
+						},
+					),
+					makeOperand(
+						false,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(5)}, &Raw{Value: decimal.NewFromFloat(6)}, &Raw{Value: decimal.NewFromFloat(-2)}, &Raw{Value: decimal.NewFromFloat(-2)}, &Raw{Bytes: []byte{0xff, 0xff}}, &Raw{Bytes: []byte{0x00, 0x00}}},
+						},
+					),
+				},
+				Output: 0,
+			},
+			makeOperand(
+				false,
+				[]ast.DataType{
+					ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0),
+				},
+				[]Tuple{
+					{&Raw{Value: decimal.NewFromFloat(5)}, &Raw{Value: decimal.NewFromFloat(6)}, &Raw{Value: decimal.NewFromFloat(-1)}, &Raw{Value: decimal.NewFromFloat(-2)}, &Raw{Bytes: []byte{0xff, 0xff}}, &Raw{Bytes: []byte{0x56, 0x78}}},
+				},
+			),
+			nil,
+		},
+	}
+
+	s.run(testcases, opFunc)
+}

--- a/core/vm/sqlvm/runtime/instructions_op_test.go
+++ b/core/vm/sqlvm/runtime/instructions_op_test.go
@@ -3693,3 +3693,65 @@ func (s *instructionSuite) TestOpRange() {
 
 	s.run(testcases, opRange)
 }
+
+func (s *instructionSuite) TestOpFuncBitAnd() {
+	testcases := []opTestcase{
+		{
+			"Func BitAnd",
+			Instruction{
+				Op: FUNC,
+				Input: []*Operand{
+					makeOperand(
+						true,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 0),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(2)}},
+						},
+					),
+					makeOperand(
+						true,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 1),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(10)}},
+						},
+					),
+					makeOperand(
+						false,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(1)}, &Raw{Value: decimal.NewFromFloat(2)}, &Raw{Value: decimal.NewFromFloat(-1)}, &Raw{Value: decimal.NewFromFloat(-128)}, &Raw{Bytes: []byte{0x12, 0x34}}, &Raw{Bytes: []byte{0x56, 0x78}}},
+						},
+					),
+					makeOperand(
+						false,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(5)}, &Raw{Value: decimal.NewFromFloat(6)}, &Raw{Value: decimal.NewFromFloat(-2)}, &Raw{Value: decimal.NewFromFloat(-2)}, &Raw{Bytes: []byte{0xff, 0xff}}, &Raw{Bytes: []byte{0x00, 0x00}}},
+						},
+					),
+				},
+				Output: 0,
+			},
+			makeOperand(
+				false,
+				[]ast.DataType{
+					ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0),
+				},
+				[]Tuple{
+					{&Raw{Value: decimal.NewFromFloat(1)}, &Raw{Value: decimal.NewFromFloat(2)}, &Raw{Value: decimal.NewFromFloat(-2)}, &Raw{Value: decimal.NewFromFloat(-128)}, &Raw{Bytes: []byte{0x12, 0x34}}, &Raw{Bytes: []byte{0x00, 0x00}}},
+				},
+			),
+			nil,
+		},
+	}
+
+	s.run(testcases, opFunc)
+}

--- a/core/vm/sqlvm/runtime/instructions_op_test.go
+++ b/core/vm/sqlvm/runtime/instructions_op_test.go
@@ -3817,3 +3817,65 @@ func (s *instructionSuite) TestOpFuncBitOr() {
 
 	s.run(testcases, opFunc)
 }
+
+func (s *instructionSuite) TestOpFuncBitXor() {
+	testcases := []opTestcase{
+		{
+			"Func BitXor",
+			Instruction{
+				Op: FUNC,
+				Input: []*Operand{
+					makeOperand(
+						true,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 0),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(2)}},
+						},
+					),
+					makeOperand(
+						true,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 1),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(12)}},
+						},
+					),
+					makeOperand(
+						false,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(1)}, &Raw{Value: decimal.NewFromFloat(2)}, &Raw{Value: decimal.NewFromFloat(-1)}, &Raw{Value: decimal.NewFromFloat(-128)}, &Raw{Bytes: []byte{0x12, 0x34}}, &Raw{Bytes: []byte{0x56, 0x78}}},
+						},
+					),
+					makeOperand(
+						false,
+						[]ast.DataType{
+							ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0),
+						},
+						[]Tuple{
+							{&Raw{Value: decimal.NewFromFloat(5)}, &Raw{Value: decimal.NewFromFloat(6)}, &Raw{Value: decimal.NewFromFloat(-2)}, &Raw{Value: decimal.NewFromFloat(-2)}, &Raw{Bytes: []byte{0xff, 0xff}}, &Raw{Bytes: []byte{0x00, 0x00}}},
+						},
+					),
+				},
+				Output: 0,
+			},
+			makeOperand(
+				false,
+				[]ast.DataType{
+					ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorUint, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorInt, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0), ast.ComposeDataType(ast.DataTypeMajorFixedBytes, 0),
+				},
+				[]Tuple{
+					{&Raw{Value: decimal.NewFromFloat(4)}, &Raw{Value: decimal.NewFromFloat(4)}, &Raw{Value: decimal.NewFromFloat(1)}, &Raw{Value: decimal.NewFromFloat(126)}, &Raw{Bytes: []byte{0xed, 0xcb}}, &Raw{Bytes: []byte{0x56, 0x78}}},
+				},
+			),
+			nil,
+		},
+	}
+
+	s.run(testcases, opFunc)
+}

--- a/core/vm/sqlvm/runtime/instructions_tmpl_data.go
+++ b/core/vm/sqlvm/runtime/instructions_tmpl_data.go
@@ -2722,5 +2722,67 @@ var testData = &tmplData{
 			},
 		},
 		// -- end of FUNC BITOR
+		{
+			TestName: "OpFuncBitXor", OpFunc: "opFunc",
+			Cases: []*tmplTestCase{
+				{
+					Name:  "Func BitXor",
+					Error: "nil", OpCode: "FUNC",
+					Inputs: []*tmplOp{
+						{
+							Im: true,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 0},
+							},
+							Data: []string{`{V: 2}`},
+						},
+						{
+							Im: true,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 1},
+							},
+							Data: []string{`{V: 12}`},
+						},
+						{
+							Im: false,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 0},
+								{Major: "Uint", Minor: 0},
+								{Major: "Int", Minor: 0},
+								{Major: "Int", Minor: 0},
+								{Major: "FixedBytes", Minor: 0},
+								{Major: "FixedBytes", Minor: 0},
+							},
+							Data: []string{"{V: 1, V: 2, V: -1, V: -128, B: {0x12, 0x34}, B: {0x56, 0x78}}"},
+						},
+						{
+							Im: false,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 0},
+								{Major: "Uint", Minor: 0},
+								{Major: "Int", Minor: 0},
+								{Major: "Int", Minor: 0},
+								{Major: "FixedBytes", Minor: 0},
+								{Major: "FixedBytes", Minor: 0},
+							},
+							Data: []string{"{V: 5, V: 6, V: -2, V: -2, B: {0xff, 0xff}, B:{0x00, 0x00}}"},
+						},
+					},
+					Output: &tmplOp{
+						Im: false,
+						Metas: []*tmplOpMeta{
+							{Major: "Uint", Minor: 0},
+							{Major: "Uint", Minor: 0},
+							{Major: "Int", Minor: 0},
+							{Major: "Int", Minor: 0},
+							{Major: "FixedBytes", Minor: 0},
+							{Major: "FixedBytes", Minor: 0},
+						},
+						Data: []string{`{V: 4, V: 4, V: 1, V: 126, B: {0xed, 0xcb}, B: {0x56, 0x78}}`},
+					},
+				},
+			},
+		},
+		// -- end of FUNC BITXOR
 	},
 }

--- a/core/vm/sqlvm/runtime/instructions_tmpl_data.go
+++ b/core/vm/sqlvm/runtime/instructions_tmpl_data.go
@@ -2598,5 +2598,67 @@ var testData = &tmplData{
 			},
 		},
 		// -- end of RANGE
+		{
+			TestName: "OpFuncBitAnd", OpFunc: "opFunc",
+			Cases: []*tmplTestCase{
+				{
+					Name:  "Func BitAnd",
+					Error: "nil", OpCode: "FUNC",
+					Inputs: []*tmplOp{
+						{
+							Im: true,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 0},
+							},
+							Data: []string{`{V: 2}`},
+						},
+						{
+							Im: true,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 1},
+							},
+							Data: []string{`{V: 10}`},
+						},
+						{
+							Im: false,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 0},
+								{Major: "Uint", Minor: 0},
+								{Major: "Int", Minor: 0},
+								{Major: "Int", Minor: 0},
+								{Major: "FixedBytes", Minor: 0},
+								{Major: "FixedBytes", Minor: 0},
+							},
+							Data: []string{"{V: 1, V: 2, V: -1, V: -128, B: {0x12, 0x34}, B: {0x56, 0x78}}"},
+						},
+						{
+							Im: false,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 0},
+								{Major: "Uint", Minor: 0},
+								{Major: "Int", Minor: 0},
+								{Major: "Int", Minor: 0},
+								{Major: "FixedBytes", Minor: 0},
+								{Major: "FixedBytes", Minor: 0},
+							},
+							Data: []string{"{V: 5, V: 6, V: -2, V: -2, B: {0xff, 0xff}, B:{0x00, 0x00}}"},
+						},
+					},
+					Output: &tmplOp{
+						Im: false,
+						Metas: []*tmplOpMeta{
+							{Major: "Uint", Minor: 0},
+							{Major: "Uint", Minor: 0},
+							{Major: "Int", Minor: 0},
+							{Major: "Int", Minor: 0},
+							{Major: "FixedBytes", Minor: 0},
+							{Major: "FixedBytes", Minor: 0},
+						},
+						Data: []string{`{V: 1, V: 2, V: -2, V: -128, B: {0x12, 0x34}, B: {0x00, 0x00}}`},
+					},
+				},
+			},
+		},
+		// -- end of FUNC BITAND
 	},
 }

--- a/core/vm/sqlvm/runtime/instructions_tmpl_data.go
+++ b/core/vm/sqlvm/runtime/instructions_tmpl_data.go
@@ -2660,5 +2660,67 @@ var testData = &tmplData{
 			},
 		},
 		// -- end of FUNC BITAND
+		{
+			TestName: "OpFuncBitOr", OpFunc: "opFunc",
+			Cases: []*tmplTestCase{
+				{
+					Name:  "Func BitOr",
+					Error: "nil", OpCode: "FUNC",
+					Inputs: []*tmplOp{
+						{
+							Im: true,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 0},
+							},
+							Data: []string{`{V: 2}`},
+						},
+						{
+							Im: true,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 1},
+							},
+							Data: []string{`{V: 11}`},
+						},
+						{
+							Im: false,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 0},
+								{Major: "Uint", Minor: 0},
+								{Major: "Int", Minor: 0},
+								{Major: "Int", Minor: 0},
+								{Major: "FixedBytes", Minor: 0},
+								{Major: "FixedBytes", Minor: 0},
+							},
+							Data: []string{"{V: 1, V: 2, V: -1, V: -128, B: {0x12, 0x34}, B: {0x56, 0x78}}"},
+						},
+						{
+							Im: false,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 0},
+								{Major: "Uint", Minor: 0},
+								{Major: "Int", Minor: 0},
+								{Major: "Int", Minor: 0},
+								{Major: "FixedBytes", Minor: 0},
+								{Major: "FixedBytes", Minor: 0},
+							},
+							Data: []string{"{V: 5, V: 6, V: -2, V: -2, B: {0xff, 0xff}, B:{0x00, 0x00}}"},
+						},
+					},
+					Output: &tmplOp{
+						Im: false,
+						Metas: []*tmplOpMeta{
+							{Major: "Uint", Minor: 0},
+							{Major: "Uint", Minor: 0},
+							{Major: "Int", Minor: 0},
+							{Major: "Int", Minor: 0},
+							{Major: "FixedBytes", Minor: 0},
+							{Major: "FixedBytes", Minor: 0},
+						},
+						Data: []string{`{V: 5, V: 6, V: -1, V: -2, B: {0xff, 0xff}, B: {0x56, 0x78}}`},
+					},
+				},
+			},
+		},
+		// -- end of FUNC BITOR
 	},
 }

--- a/core/vm/sqlvm/runtime/instructions_tmpl_data.go
+++ b/core/vm/sqlvm/runtime/instructions_tmpl_data.go
@@ -2784,5 +2784,55 @@ var testData = &tmplData{
 			},
 		},
 		// -- end of FUNC BITXOR
+		{
+			TestName: "OpFuncBitNot", OpFunc: "opFunc",
+			Cases: []*tmplTestCase{
+				{
+					Name:  "Func BitNot",
+					Error: "nil", OpCode: "FUNC",
+					Inputs: []*tmplOp{
+						{
+							Im: true,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 0},
+							},
+							Data: []string{`{V: 2}`},
+						},
+						{
+							Im: true,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 1},
+							},
+							Data: []string{`{V: 13}`},
+						},
+						{
+							Im: false,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 0},
+								{Major: "Uint", Minor: 0},
+								{Major: "Int", Minor: 0},
+								{Major: "Int", Minor: 0},
+								{Major: "FixedBytes", Minor: 0},
+								{Major: "FixedBytes", Minor: 0},
+							},
+							Data: []string{"{V: 128, V: 0, V: -1, V: -128, B: {0x12, 0x34}, B: {0xff, 0x00}}"},
+						},
+					},
+					Output: &tmplOp{
+						Im: false,
+						Metas: []*tmplOpMeta{
+							{Major: "Uint", Minor: 0},
+							{Major: "Uint", Minor: 0},
+							{Major: "Int", Minor: 0},
+							{Major: "Int", Minor: 0},
+							{Major: "FixedBytes", Minor: 0},
+							{Major: "FixedBytes", Minor: 0},
+						},
+						Data: []string{`{V: 127, V: 255, V: 0, V: 127, B: {0xed, 0xcb}, B: {0x00, 0xff}}`},
+					},
+				},
+			},
+		},
+		// -- end of FUNC BITNOT
 	},
 }

--- a/core/vm/sqlvm/runtime/instructions_tmpl_data.go
+++ b/core/vm/sqlvm/runtime/instructions_tmpl_data.go
@@ -2834,5 +2834,53 @@ var testData = &tmplData{
 			},
 		},
 		// -- end of FUNC BITNOT
+		{
+			TestName: "OpFuncOctetLength", OpFunc: "opFunc",
+			Cases: []*tmplTestCase{
+				{
+					Name:  "Func octet length",
+					Error: "nil", OpCode: "FUNC",
+					Inputs: []*tmplOp{
+						{
+							Im: true,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 0},
+							},
+							Data: []string{`{V: 2}`},
+						},
+						{
+							Im: true,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 1},
+							},
+							Data: []string{`{V: 14}`},
+						},
+						{
+							Im: false,
+							Metas: []*tmplOpMeta{
+								{Major: "DynamicBytes", Minor: 0},
+								{Major: "DynamicBytes", Minor: 0},
+								{Major: "DynamicBytes", Minor: 0},
+								{Major: "DynamicBytes", Minor: 0},
+								{Major: "DynamicBytes", Minor: 0},
+							},
+							Data: []string{"{B: {}, B: {1}, B: {1, 2}, B: {1, 2, 3}, B: {1, 2, 3, 4}}"},
+						},
+					},
+					Output: &tmplOp{
+						Im: false,
+						Metas: []*tmplOpMeta{
+							{Major: "Uint", Minor: 32},
+							{Major: "Uint", Minor: 32},
+							{Major: "Uint", Minor: 32},
+							{Major: "Uint", Minor: 32},
+							{Major: "Uint", Minor: 32},
+						},
+						Data: []string{`{V: 0, V: 1, V: 2, V: 3, V: 4}`},
+					},
+				},
+			},
+		},
+		// -- end of FUNC OCTETLENGTH
 	},
 }

--- a/core/vm/sqlvm/runtime/instructions_tmpl_data.go
+++ b/core/vm/sqlvm/runtime/instructions_tmpl_data.go
@@ -2882,5 +2882,59 @@ var testData = &tmplData{
 			},
 		},
 		// -- end of FUNC OCTETLENGTH
+		{
+			TestName: "OpFuncSubString", OpFunc: "opFunc",
+			Cases: []*tmplTestCase{
+				{
+					Name:  "Func sub string",
+					Error: "nil", OpCode: "FUNC",
+					Inputs: []*tmplOp{
+						{
+							Im: true,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 0},
+							},
+							Data: []string{`{V: 2}`},
+						},
+						{
+							Im: true,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 1},
+							},
+							Data: []string{`{V: 15}`},
+						},
+						{
+							Im: false,
+							Metas: []*tmplOpMeta{
+								{Major: "DynamicBytes", Minor: 0},
+							},
+							Data: []string{"{B: {1, 2, 3, 4, 5, 6, 7, 8, 9}}"},
+						},
+						{
+							Im: true,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 7},
+							},
+							Data: []string{`{V: 2}`},
+						},
+						{
+							Im: true,
+							Metas: []*tmplOpMeta{
+								{Major: "Uint", Minor: 7},
+							},
+							Data: []string{`{V: 5}`},
+						},
+					},
+					Output: &tmplOp{
+						Im: false,
+						Metas: []*tmplOpMeta{
+							{Major: "DynamicBytes", Minor: 0},
+						},
+						Data: []string{"{B: {3, 4, 5, 6, 7}}"},
+					},
+				},
+			},
+		},
+		// -- end of FUNC SUBSTRING
 	},
 }


### PR DESCRIPTION
Including following functions:
* BITAND
* BITOR
* BITXOR
* BITNOT
* OCTECT_LENGTH
* SUBSTRING